### PR TITLE
Together.ai provider added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2.11.0
+
+This release notably includes a significant UI improvement for the chat side panel. The chat UI now uses the native JupyterLab frontend to render Markdown, code blocks, and TeX markup instead of a third party package. Thank you to @andrii-i for building this feature!
+
+([Full Changelog](https://github.com/jupyterlab/jupyter-ai/compare/@jupyter-ai/core@2.10.0...642ac533ef05e2bf7f4a6739b377c7138154bb69))
+
+### Enhancements made
+
+- Fix cookiecutter template [#637](https://github.com/jupyterlab/jupyter-ai/pull/637) ([@dlqqq](https://github.com/dlqqq))
+- Add OpenAI text-embedding-3-small, -large models [#628](https://github.com/jupyterlab/jupyter-ai/pull/628) ([@JasonWeill](https://github.com/JasonWeill))
+- Add new OpenAI models [#625](https://github.com/jupyterlab/jupyter-ai/pull/625) ([@EduardDurech](https://github.com/EduardDurech))
+- Use @jupyterlab/rendermime for in-chat markdown rendering [#564](https://github.com/jupyterlab/jupyter-ai/pull/564) ([@andrii-i](https://github.com/andrii-i))
+
+### Bugs fixed
+
+- Unifies parameters to instantiate llm while incorporating model params [#632](https://github.com/jupyterlab/jupyter-ai/pull/632) ([@JasonWeill](https://github.com/JasonWeill))
+
+### Documentation improvements
+
+- Add `nodejs=20` to the contributing docs [#645](https://github.com/jupyterlab/jupyter-ai/pull/645) ([@jtpio](https://github.com/jtpio))
+- Update docs to mention `langchain_community.llms` [#642](https://github.com/jupyterlab/jupyter-ai/pull/642) ([@jtpio](https://github.com/jtpio))
+- Fix cookiecutter template [#637](https://github.com/jupyterlab/jupyter-ai/pull/637) ([@dlqqq](https://github.com/dlqqq))
+- Fix conda-forge typo in readme [#626](https://github.com/jupyterlab/jupyter-ai/pull/626) ([@droumis](https://github.com/droumis))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyter-ai/graphs/contributors?from=2024-02-06&to=2024-03-04&type=c))
+
+[@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Aandrii-i+updated%3A2024-02-06..2024-03-04&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Adlqqq+updated%3A2024-02-06..2024-03-04&type=Issues) | [@droumis](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Adroumis+updated%3A2024-02-06..2024-03-04&type=Issues) | [@EduardDurech](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3AEduardDurech+updated%3A2024-02-06..2024-03-04&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3AJasonWeill+updated%3A2024-02-06..2024-03-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Ajtpio+updated%3A2024-02-06..2024-03-04&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Akrassowski+updated%3A2024-02-06..2024-03-04&type=Issues) | [@lalanikarim](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Alalanikarim+updated%3A2024-02-06..2024-03-04&type=Issues) | [@lumberbot-app](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Alumberbot-app+updated%3A2024-02-06..2024-03-04&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Awelcome+updated%3A2024-02-06..2024-03-04&type=Issues) | [@Wzixiao](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3AWzixiao+updated%3A2024-02-06..2024-03-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2.10.0
 
 This is the first public release of Jupyter AI inline completion, initially developed by @krassowski. Inline completion requires `jupyterlab==4.1.0` to work, so make sure you have that installed if you want to try it out! 🎉
@@ -39,8 +71,6 @@ This is the first public release of Jupyter AI inline completion, initially deve
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyter-ai/graphs/contributors?from=2024-01-22&to=2024-02-06&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3A3coins+updated%3A2024-01-22..2024-02-06&type=Issues) | [@adriens](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Aadriens+updated%3A2024-01-22..2024-02-06&type=Issues) | [@aws-khatria](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Aaws-khatria+updated%3A2024-01-22..2024-02-06&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Adlqqq+updated%3A2024-01-22..2024-02-06&type=Issues) | [@garsonbyte](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Agarsonbyte+updated%3A2024-01-22..2024-02-06&type=Issues) | [@JasonWeill](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3AJasonWeill+updated%3A2024-01-22..2024-02-06&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Akrassowski+updated%3A2024-01-22..2024-02-06&type=Issues) | [@lumberbot-app](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Alumberbot-app+updated%3A2024-01-22..2024-02-06&type=Issues) | [@stevie-35](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Astevie-35+updated%3A2024-01-22..2024-02-06&type=Issues) | [@Tom-A-Lynch](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3ATom-A-Lynch+updated%3A2024-01-22..2024-02-06&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyter-ai+involves%3Awelcome+updated%3A2024-01-22..2024-02-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2.10.0-beta.1
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "2.10.0",
+  "version": "2.11.0",
   "npmClient": "yarn",
   "useNx": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-ai/monorepo",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "A generative AI extension for JupyterLab",
   "private": true,
   "keywords": [

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/__init__.py
@@ -29,6 +29,7 @@ from .providers import (
     OpenAIProvider,
     QianfanProvider,
     SmEndpointProvider,
+    TogetherAIProvider,
 )
 
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -31,13 +31,13 @@ from langchain_community.chat_models import (
 from langchain_community.llms import (
     AI21,
     Anthropic,
-    Together,
     Bedrock,
     Cohere,
     GPT4All,
     HuggingFaceHub,
     OpenAI,
     SagemakerEndpoint,
+    Together,
 )
 
 # this is necessary because `langchain.pydantic_v1.main` does not include
@@ -858,17 +858,18 @@ class TogetherAIProvider(BaseProvider, Together):
     id = "togetherai"
     name = "Together AI"
     model_id_key = "model"
-    models = ['Austism/chronos-hermes-13b',
-              'DiscoResearch/DiscoLM-mixtral-8x7b-v2',
-              'EleutherAI/llemma_7b',
-              'Gryphe/MythoMax-L2-13b',
-              'Meta-Llama/Llama-Guard-7b',
-              'Nexusflow/NexusRaven-V2-13B',
-              'NousResearch/Nous-Capybara-7B-V1p9',
-              'NousResearch/Nous-Hermes-2-Yi-34B',
-              'NousResearch/Nous-Hermes-Llama2-13b',
-              'NousResearch/Nous-Hermes-Llama2-70b'
-              ]
+    models = [
+        "Austism/chronos-hermes-13b",
+        "DiscoResearch/DiscoLM-mixtral-8x7b-v2",
+        "EleutherAI/llemma_7b",
+        "Gryphe/MythoMax-L2-13b",
+        "Meta-Llama/Llama-Guard-7b",
+        "Nexusflow/NexusRaven-V2-13B",
+        "NousResearch/Nous-Capybara-7B-V1p9",
+        "NousResearch/Nous-Hermes-2-Yi-34B",
+        "NousResearch/Nous-Hermes-Llama2-13b",
+        "NousResearch/Nous-Hermes-Llama2-70b",
+    ]
     pypi_package_deps = ["together"]
     auth_strategy = EnvAuthStrategy(name="TOGETHER_API_KEY")
 
@@ -876,7 +877,9 @@ class TogetherAIProvider(BaseProvider, Together):
         model = kwargs.get("model_id")
 
         if model not in self.models:
-            kwargs["responses"] = ["Model not supported! Please check model list with %ai list"]
+            kwargs["responses"] = [
+                "Model not supported! Please check model list with %ai list"
+            ]
 
         super().__init__(**kwargs)
 

--- a/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
+++ b/packages/jupyter-ai-magics/jupyter_ai_magics/providers.py
@@ -31,6 +31,7 @@ from langchain_community.chat_models import (
 from langchain_community.llms import (
     AI21,
     Anthropic,
+    Together,
     Bedrock,
     Cohere,
     GPT4All,
@@ -851,6 +852,41 @@ class BedrockChatProvider(BaseProvider, BedrockChat):
     @property
     def allows_concurrency(self):
         return not "anthropic" in self.model_id
+
+
+class TogetherAIProvider(BaseProvider, Together):
+    id = "togetherai"
+    name = "Together AI"
+    model_id_key = "model"
+    models = ['Austism/chronos-hermes-13b',
+              'DiscoResearch/DiscoLM-mixtral-8x7b-v2',
+              'EleutherAI/llemma_7b',
+              'Gryphe/MythoMax-L2-13b',
+              'Meta-Llama/Llama-Guard-7b',
+              'Nexusflow/NexusRaven-V2-13B',
+              'NousResearch/Nous-Capybara-7B-V1p9',
+              'NousResearch/Nous-Hermes-2-Yi-34B',
+              'NousResearch/Nous-Hermes-Llama2-13b',
+              'NousResearch/Nous-Hermes-Llama2-70b'
+              ]
+    pypi_package_deps = ["together"]
+    auth_strategy = EnvAuthStrategy(name="TOGETHER_API_KEY")
+
+    def __init__(self, **kwargs):
+        model = kwargs.get("model_id")
+
+        if model not in self.models:
+            kwargs["responses"] = ["Model not supported! Please check model list with %ai list"]
+
+        super().__init__(**kwargs)
+
+    def get_prompt_template(self, format) -> PromptTemplate:
+        if format == "code":
+            return PromptTemplate.from_template(
+                "{prompt}\n\nProduce output as source code only, "
+                "with no text or explanation before or after it."
+            )
+        return super().get_prompt_template(format)
 
 
 # Baidu QianfanChat provider. temporarily living as a separate class until

--- a/packages/jupyter-ai-magics/package.json
+++ b/packages/jupyter-ai-magics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-ai/magics",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Jupyter AI magics Python package. Not published on NPM.",
   "private": true,
   "homepage": "https://github.com/jupyterlab/jupyter-ai",

--- a/packages/jupyter-ai-magics/pyproject.toml
+++ b/packages/jupyter-ai-magics/pyproject.toml
@@ -46,6 +46,8 @@ all = [
     "openai~=1.6.1",
     "boto3",
     "qianfan",
+    "together",
+
 ]
 
 [project.entry-points."jupyter_ai.model_providers"]
@@ -63,6 +65,7 @@ anthropic-chat = "jupyter_ai_magics:ChatAnthropicProvider"
 amazon-bedrock-chat = "jupyter_ai_magics:BedrockChatProvider"
 qianfan = "jupyter_ai_magics:QianfanProvider"
 nvidia-chat = "jupyter_ai_magics.partner_providers.nvidia:ChatNVIDIAProvider"
+together-ai = "jupyter_ai_magics:TogetherAIProvider"
 
 [project.entry-points."jupyter_ai.embeddings_model_providers"]
 bedrock = "jupyter_ai_magics:BedrockEmbeddingsProvider"

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-ai/core",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "A generative AI extension for JupyterLab",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/649

Together.ai is getting popular for running community open models on their cloud platform, and looks like it would be good to have in Jupyter AI by default.


- [x]  Add TogetherAIProvider
- [x] Expand the list of available models

- [ ]  Add TogetherAIEmbeddingsProvider
- [ ]  Add documentation
- [ ]  Mark as experimental, like for GPT4All?